### PR TITLE
fix: Change date format of shipped_at and add test related

### DIFF
--- a/models/staging/bikes_database/stg_bikes_database__orders.sql
+++ b/models/staging/bikes_database/stg_bikes_database__orders.sql
@@ -1,6 +1,7 @@
 -- store_id not used because can be retrieved with link to table staffs
 -- order_status reworked until I know what is the difference between statuses 1, 2 and 3; 4 is shipped
--- required_date because I do not know what it means: can't extract value from it
+-- required_date removed because I do not know what it means: can't extract value from it
+-- shipped_date reworked: putting actual null values instead of 'NULL', then transform to DATE column
 SELECT
     order_id,
     customer_id,
@@ -12,5 +13,5 @@ SELECT
     END AS shipped_status,
     order_date AS ordered_at,
 --    required_date,
-    shipped_date AS shipped_at
+    PARSE_DATE('%Y-%m-%d', NULLIF(shipped_date, 'NULL')) as shipped_at
 FROM {{ source('bike_raw_data', 'orders') }}

--- a/tests/assert_shipped_is_after_ordered.sql
+++ b/tests/assert_shipped_is_after_ordered.sql
@@ -1,0 +1,4 @@
+SELECT *
+FROM {{ ref('stg_bikes_database__orders') }}
+WHERE 
+    DATE_DIFF(shipped_at, ordered_at, DAY) < 0

--- a/tests/schema.yml
+++ b/tests/schema.yml
@@ -5,6 +5,10 @@ data_tests:
     description: >
       Discount is a deducted percentage of the price, so it should be between 0 (0%) and 1 (100%).
       Therefore return records where min_discount < 0 or max_discount > 1 make the test fail.
+  - name: assert_shipped_is_after_ordered
+    description: >
+      An order should always be shipped after it has been ordered, never before.
+      Therefore return records where a date_diff (in days) is < 0 make the test fail.
   - name: assert_stock_quantity_is_not_negative
     description: >
       Stock is a remaining quantity, so it should always be >= 0.


### PR DESCRIPTION
In this PR, I do different changes:
- first, I change the format of the shipped_at column in the order table, from string to date,
- then, I add a test to check that an order is always shipped after it has been ordered. I also update the schema.yml to add the description for this test.