### PR TITLE
fix: Rename fields, change data type and correct duplicates issue

### DIFF
--- a/models/intermediate/bikes_database/int_bikes_database__order_products.sql
+++ b/models/intermediate/bikes_database/int_bikes_database__order_products.sql
@@ -1,7 +1,7 @@
 SELECT
     p.product_id,
-    p.category_id,
     p.brand_id,
+    p.category_id,
     oi.order_id,
     p.product_name,
     p.list_price,

--- a/models/intermediate/bikes_database/int_bikes_database__orders.sql
+++ b/models/intermediate/bikes_database/int_bikes_database__orders.sql
@@ -29,17 +29,17 @@ SELECT
     oe.shipped_status,
     oe.ordered_at,
     oe.shipped_at,
-    c.first_name AS customer_first_name,
-    c.last_name AS customer_last_name,
-    c.city AS customer_city,
-    c.state AS customer_state,
-    c.zip_code AS customer_zip_code,
-    sta.first_name AS staff_first_name,
-    sta.last_name AS staff_last_name,
+    c.customer_first_name,
+    c.customer_last_name,
+    c.customer_city,
+    c.customer_state,
+    c.customer_zip_code,
+    sta.staff_first_name,
+    sta.staff_last_name,
     sto.store_name,
-    sto.city AS store_city,
-    sto.state AS store_state,
-    sto.zip_code AS store_zip_code,
+    sto.store_city,
+    sto.store_state,
+    sto.store_zip_code,
     oe.total_quantity,
     oe.total_amount,
     oe.total_discounted_amount
@@ -50,8 +50,8 @@ INNER JOIN ( -- selecting only active staff members
         staff_id,
         store_id,
         manager_id,
-        first_name,
-        last_name
+        staff_first_name,
+        staff_last_name
     FROM {{ ref('stg_bikes_database__staffs') }}
     WHERE active = 1
 ) sta ON oe.staff_id = sta.staff_id

--- a/models/staging/bikes_database/stg_bikes_database__brands.sql
+++ b/models/staging/bikes_database/stg_bikes_database__brands.sql
@@ -1,4 +1,4 @@
 SELECT
-    brand_id,
-    brand_name
+    brand_id, -- 9 distinct
+    brand_name -- 9 distinct
 FROM {{ source('bike_raw_data', 'brands') }}

--- a/models/staging/bikes_database/stg_bikes_database__categories.sql
+++ b/models/staging/bikes_database/stg_bikes_database__categories.sql
@@ -1,4 +1,4 @@
 SELECT
-    category_id,
-    category_name
+    category_id, -- 7 distinct
+    category_name -- 7 distinct
 FROM {{ source('bike_raw_data', 'categories') }}

--- a/models/staging/bikes_database/stg_bikes_database__customers.sql
+++ b/models/staging/bikes_database/stg_bikes_database__customers.sql
@@ -1,12 +1,12 @@
 -- TODO: anonymize instead of not importing?
 SELECT
-    customer_id,
-    first_name,
-    last_name,
---    phone,
---    email,
---    street,
-    city,
-    state,
-    zip_code
+    customer_id, -- 1445 distinct
+    first_name AS customer_first_name,
+    last_name AS customer_last_name,
+--    phone AS customer_phone,
+--    email AS customer_email,
+--    street AS customer_street,
+    city AS customer_city, -- 195 distinct
+    state AS customer_state, -- 3 distinct
+    zip_code AS customer_zip_code -- 195 distinct
 FROM {{ source('bike_raw_data', 'customers') }}

--- a/models/staging/bikes_database/stg_bikes_database__order_items.sql
+++ b/models/staging/bikes_database/stg_bikes_database__order_items.sql
@@ -1,11 +1,11 @@
 -- item_id not used: brings no new information
 -- list_price removed: already in Products table
 SELECT
-    CONCAT(order_id, '_', product_id) AS order_item_id,
-    order_id,
+    CONCAT(order_id, '_', product_id) AS order_item_id, -- 4722 distinct
+    order_id, -- 1615 distinct
 --    item_id,
-    product_id,
+    product_id, -- 307 distinct
     quantity,
 --    list_price,
-    discount
+    discount -- 4 distinct: .05, .07, .1, .2
 FROM {{ source('bike_raw_data', 'order_items') }}

--- a/models/staging/bikes_database/stg_bikes_database__orders.sql
+++ b/models/staging/bikes_database/stg_bikes_database__orders.sql
@@ -3,10 +3,10 @@
 -- required_date removed because I do not know what it means: can't extract value from it
 -- shipped_date reworked: putting actual null values instead of 'NULL', then transform to DATE column
 SELECT
-    order_id,
-    customer_id,
+    order_id, -- 1615 distinct
+    customer_id, -- 1445 distinct
 --    store_id,
-    staff_id,
+    staff_id, -- 6 distinct
     CASE
         WHEN order_status IN (1, 2, 3) THEN 0
         ELSE 1

--- a/models/staging/bikes_database/stg_bikes_database__products.sql
+++ b/models/staging/bikes_database/stg_bikes_database__products.sql
@@ -1,8 +1,16 @@
+-- 321 distinct product_id versus 291 distinct product_name: problem is some products have different category_id
+-- some are in categories 5-3-2, others in 3-2, others in 3-1: here I choose to only keep the max value
+-- and I take the min of product_id to secure the deduplication
 SELECT
-    product_id,
+    MIN(product_id) AS product_id,
+    brand_id, -- 9 distinct
+    MAX(category_id) AS category_id, -- 7 distinct
+    product_name,
+    model_year, -- 4 distinct: 2016, 2017, 2018, 2019
+    list_price
+FROM {{ source('bike_raw_data', 'products') }}
+GROUP BY
     brand_id,
-    category_id,
     product_name,
     model_year,
     list_price
-FROM {{ source('bike_raw_data', 'products') }}

--- a/models/staging/bikes_database/stg_bikes_database__staffs.sql
+++ b/models/staging/bikes_database/stg_bikes_database__staffs.sql
@@ -1,11 +1,11 @@
--- If many rows, change manager_id to INT for storage optimization => change "NULL" to 0 for instance
+-- Change manager_id to INT for storage optimization
 SELECT
-    staff_id,
-    store_id,
-    manager_id,
-    first_name,
-    last_name,
---    email,
---    phone,
+    staff_id, -- 10 distinct
+    store_id, -- 3 distinct
+    SAFE_CAST(NULLIF(manager_id, 'NULL') AS INT) AS manager_id,
+    first_name AS staff_first_name,
+    last_name AS staff_last_name,
+--    email AS staff_email,
+--    phone AS staff_phone,
     active
 FROM {{ source('bike_raw_data', 'staffs') }}

--- a/models/staging/bikes_database/stg_bikes_database__stocks.sql
+++ b/models/staging/bikes_database/stg_bikes_database__stocks.sql
@@ -1,6 +1,6 @@
 SELECT
-    CONCAT(store_id, '_', product_id) AS stock_id,
-    store_id,
-    product_id,
+    CONCAT(store_id, '_', product_id) AS stock_id, -- 3 x 313 = 939 distinct
+    store_id, -- 3 distinct
+    product_id, -- 313 distinct
     quantity
 FROM {{ source('bike_raw_data', 'stocks') }}

--- a/models/staging/bikes_database/stg_bikes_database__stores.sql
+++ b/models/staging/bikes_database/stg_bikes_database__stores.sql
@@ -1,10 +1,10 @@
 SELECT
-    store_id,
-    store_name,
+    store_id, -- 3 distinct
+    store_name, -- 3 distinct
 --    phone,
 --    email,
 --    street,
-    city,
-    state,
-    zip_code
+    city AS store_city,
+    state AS store_state,
+    zip_code AS store_zip_code
 FROM {{ source('bike_raw_data', 'stores') }}


### PR DESCRIPTION
In this PR:
- I change the type of the column manager_id in stg_staffs: from string to int
- I rename fields from stg_customers, stg_staffs and stg_stores to distinguish city, first_name, etc, and I fix the reference to these fields in int_orders
- I fix the duplicates from stg_products: by only choosing 1 category for each product