### PR TITLE
feat: Change first_name and last_name to full_name for staff

### DIFF
--- a/models/intermediate/bikes_database/int_bikes_database__orders.sql
+++ b/models/intermediate/bikes_database/int_bikes_database__orders.sql
@@ -29,13 +29,10 @@ SELECT
     oe.shipped_status,
     oe.ordered_at,
     oe.shipped_at,
-    c.customer_first_name,
-    c.customer_last_name,
     c.customer_city,
     c.customer_state,
     c.customer_zip_code,
-    sta.staff_first_name,
-    sta.staff_last_name,
+    sta.staff_full_name,
     sto.store_name,
     sto.store_city,
     sto.store_state,
@@ -50,8 +47,7 @@ INNER JOIN ( -- selecting only active staff members
         staff_id,
         store_id,
         manager_id,
-        staff_first_name,
-        staff_last_name
+        staff_full_name
     FROM {{ ref('stg_bikes_database__staffs') }}
     WHERE active = 1
 ) sta ON oe.staff_id = sta.staff_id

--- a/models/mart/mrt_sales_report.sql
+++ b/models/mart/mrt_sales_report.sql
@@ -6,7 +6,8 @@ SELECT
 --    manager_id,
     shipped_status,
     customer_city,
-    store_city,
+    staff_full_name,
+    store_name,
     SUM(total_quantity) AS total_quantity,
     ROUND(SUM(total_amount), 2) AS total_amount,
     ROUND(SUM(total_discounted_amount), 2) AS total_discounted_amount,
@@ -22,6 +23,7 @@ GROUP BY
 --    report_day,
     shipped_status,
     customer_city,
-    store_city
+    staff_full_name,
+    store_name
 ORDER BY 
     report_date

--- a/models/staging/bikes_database/stg_bikes_database__customers.sql
+++ b/models/staging/bikes_database/stg_bikes_database__customers.sql
@@ -1,8 +1,8 @@
 -- TODO: anonymize instead of not importing?
 SELECT
     customer_id, -- 1445 distinct
-    first_name AS customer_first_name,
-    last_name AS customer_last_name,
+--    first_name AS customer_first_name,
+--    last_name AS customer_last_name,
 --    phone AS customer_phone,
 --    email AS customer_email,
 --    street AS customer_street,

--- a/models/staging/bikes_database/stg_bikes_database__staffs.sql
+++ b/models/staging/bikes_database/stg_bikes_database__staffs.sql
@@ -3,8 +3,9 @@ SELECT
     staff_id, -- 10 distinct
     store_id, -- 3 distinct
     SAFE_CAST(NULLIF(manager_id, 'NULL') AS INT) AS manager_id,
-    first_name AS staff_first_name,
-    last_name AS staff_last_name,
+--    first_name AS staff_first_name,
+--    last_name AS staff_last_name,
+    CONCAT(first_name, ' ', last_name) AS staff_full_name,
 --    email AS staff_email,
 --    phone AS staff_phone,
     active


### PR DESCRIPTION
In this PR:
- I remove the names from stg customers since I don't use it later,
- I remove the first_name, last_name from stg staff, and instead add the full_name,
- I fix the references to these fields in int orders and sales report, and also change the store city reference in sales report to store name